### PR TITLE
functionの定義位置を修正

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -6,23 +6,6 @@ $choice = new-object "System.Collections.ObjectModel.Collection``1[[$assembly]]"
 $choice.add($yes);
 $choice.add($no);
 
-# First
-$answer = $host.UI.PromptForChoice("<実行確認>", "インストールを開始しますか？", $choice, 0);
-if ($answer -eq 0) {
-    $answer = $host.UI.PromptForChoice("<Chocolateyインストール>", "Chocolateyのインストールを行いますか？", $choice, 0);
-    if ($answer -eq 0) {
-        ChocoSetup;
-    }
-    $answer = $host.UI.PromptForChoice("<Packageインストール>", "Packageのインストールを行いますか？", $choice, 0);
-    if ($answer -eq 0) {
-        ChocoPackageInstall;
-    }
-    $answer = $host.UI.PromptForChoice("<Packageアップデート>", "Packageのアップデートを行いますか？", $choice, 0);
-    if ($answer -eq 0) {
-        ChocoPackageUpdate;
-    }
-}
-
 # Setup
 function ChocoSetup() {
     iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'));
@@ -57,3 +40,21 @@ function ChocoPackageUpdate() {
     choco update chocolateygui -y;
     choco update winscp -y;
 }
+
+# Main
+$answer = $host.UI.PromptForChoice("<実行確認>", "インストールを開始しますか？", $choice, 0);
+if ($answer -eq 0) {
+    $answer = $host.UI.PromptForChoice("<Chocolateyインストール>", "Chocolateyのインストールを行いますか？", $choice, 0);
+    if ($answer -eq 0) {
+        ChocoSetup;
+    }
+    $answer = $host.UI.PromptForChoice("<Packageインストール>", "Packageのインストールを行いますか？", $choice, 0);
+    if ($answer -eq 0) {
+        ChocoPackageInstall;
+    }
+    $answer = $host.UI.PromptForChoice("<Packageアップデート>", "Packageのアップデートを行いますか？", $choice, 0);
+    if ($answer -eq 0) {
+        ChocoPackageUpdate;
+    }
+}
+


### PR DESCRIPTION
## 関連URL
- Windows PowerShell ISE以外でps1が動かない #1

## 概要
- Windows PowerShell ISE以外でも正常に動作するように修正する
- 原因は、functionの定義が呼び出し位置よりも下にある場合、正常にfunctionが呼び出せないため

## 影響範囲・ターゲットユーザ
- 全て

## 技術的変更点概要
- functionの定義位置をMainの上に移動する

## 使い方
- なし

## UIに対する変更
- なし

## マイグレーション
- なし

## クエリに対する変更
- なし

## TDログ
- [　] 重要な機能であり、ログを仕込んだ
- [X] ログを入れる必要なし

## テスト結果とテスト項目
- [X] PwerShellを起動する
- [X] setup.ps1を実行する
- [X] すべての質問に[YES]で回答して正常に動作することを確認する。

## 今回保留した項目とTODOリスト
- chocolateyのupdateを追加する #2
- インストールするpackageを追加する #3

## その他
- なし
