### PR TITLE
導入パッケージをconfigファイルでまとめる

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="git" />
+    <package id="vagrant" />
+    <package id="terraform" />
+    <package id="terraform-provider-sakuracloud" />
+    <package id="usacloud" />
+    <package id="keepass" />
+    <package id="rdcman" />
+    <package id="visualstudiocode" />
+    <package id="wireshark" />
+    <package id="teraterm" />
+    <package id="bginfo" />
+    <package id="zoomit" />
+    <package id="hosts.editor" />
+    <package id="sourcetree" />
+    <package id="chocolateygui" />
+    <package id="winscp" />
+</packages>

--- a/setup.ps1
+++ b/setup.ps1
@@ -8,64 +8,36 @@ $choice.add($no);
 
 # Setup
 function ChocoSetup() {
-    iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'));
+    Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'));
 }
 
 # Package Install
 function ChocoPackageInstall() {
-    choco install git -y;
-    choco install vagrant -y;
-    choco install terraform -y;
-    choco install terraform-provider-sakuracloud -y;
-    choco install usacloud -y;
-    choco install keepass -y;
-    choco install rdcman -y;
-    choco install visualstudiocode -y;
-    choco install wireshark -y;
-    choco install teraterm -y;
-    #choco install bginfo -y;  # Errorが発生する
-    choco install zoomit -y;
-    choco install hosts.editor -y;
-    choco install sourcetree -y;
-    choco install chocolateygui -y;
-    choco install winscp -y;
+    cinst .\packages.config -y;
 }
 
 # Package update
 function ChocoPackageUpdate() {
-    choco update git -y;
-    choco update vagrant -y;
-    choco update terraform -y;
-    choco update terraform-provider-sakuracloud -y;
-    choco update usacloud -y;
-    choco update chocolatey -y;
-    choco update keepass -y;
-    choco update rdcman -y;
-    choco update visualstudiocode -y;
-    choco update wireshark -y;
-    choco update teraterm -y;
-    #choco update bginfo -y;  # Errorが発生する
-    choco update zoomit -y;
-    choco update hosts.editor -y;
-    choco update sourcetree -y;
-    choco update chocolateygui -y;
-    choco update winscp -y;
+    $packagesInfo = [xml](Get-Content "$PSScriptRoot\packages.config");
+    $packageList = [string]::Empty;
+    foreach ($packageInfo in $packagesInfo.packages) {
+        $packageList = $packageList + $packageInfo.package.id + " ";
+    }
+    $cmd = "choco update $packageList -y;";
+    Write-Host $cmd;
+    Invoke-Expression $cmd;
 }
 
 # Main
-$answer = $host.UI.PromptForChoice("<実行確認>", "インストールを開始しますか？", $choice, 0);
+$answer = $host.UI.PromptForChoice("<Chocolateyインストール>", "Chocolateyのインストールを行いますか？", $choice, 0);
 if ($answer -eq 0) {
-    $answer = $host.UI.PromptForChoice("<Chocolateyインストール>", "Chocolateyのインストールを行いますか？", $choice, 0);
-    if ($answer -eq 0) {
-        ChocoSetup;
-    }
-    $answer = $host.UI.PromptForChoice("<Packageインストール>", "Packageのインストールを行いますか？", $choice, 0);
-    if ($answer -eq 0) {
-        ChocoPackageInstall;
-    }
-    $answer = $host.UI.PromptForChoice("<Packageアップデート>", "Packageのアップデートを行いますか？", $choice, 0);
-    if ($answer -eq 0) {
-        ChocoPackageUpdate;
-    }
+    ChocoSetup;
 }
-
+$answer = $host.UI.PromptForChoice("<Packageインストール>", "Packageのインストールを行いますか？", $choice, 0);
+if ($answer -eq 0) {
+    ChocoPackageInstall;
+}
+$answer = $host.UI.PromptForChoice("<Packageアップデート>", "Packageのアップデートを行いますか？", $choice, 0);
+if ($answer -eq 0) {
+    ChocoPackageUpdate;
+}


### PR DESCRIPTION
## 関連URL
- 導入パッケージをconfigファイルでまとめる #8

## 概要
- スクリプトに直書きしているパッケージリストをconfigファイルに外だしする

## 影響範囲・ターゲットユーザ
- 全て

## 技術的変更点概要
- packages.configを追加
- インストールは、cinst .\packages.config -yで行う。
- アップデートは、packages.configを読みだしてコマンドを生成し、Invoke-Expressionで実行する

## 使い方
- PwerShellを起動する
- setup.ps1を実行する
- 「Packageのインストールを行いますか？」でYを入力する
- 追加したパッケージを含むインストールが開始される
- 「Packageのアップデートを行いますか？」でYを入力する
- 追加したパッケージを含むアップデートが開始される

## UIに対する変更
- なし

## マイグレーション
- なし

## クエリに対する変更
- なし

## TDログ
- [　] 重要な機能であり、ログを仕込んだ
- [X] ログを入れる必要なし

## テスト結果とテスト項目
- [X] PwerShellを起動する
- [X] setup.ps1を実行する
- [X] 「Packageのインストールを行いますか？」でYを入力する
- [X] 追加したパッケージを含むインストールが開始される
- [X] 「Packageのアップデートを行いますか？」でYを入力する
- [X] 追加したパッケージを含むアップデートが開始される

## 今回保留した項目とTODOリスト
- なし

## その他
- なし
